### PR TITLE
docs: fix typo 'hex notation'

### DIFF
--- a/badgers-web/src/app/page.tsx
+++ b/badgers-web/src/app/page.tsx
@@ -104,7 +104,7 @@ export default function Home() {
                 <div className="text-sm text-gray-600">
                     We also support{' '}
                     <abbr title="examples: fff, 24c66b, c624a0...">
-                        hex annotation
+                        hex notation
                     </abbr>{' '}
                     for custom colors.
                 </div>


### PR DESCRIPTION
## Summary
- fix a typo in the custom colors description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846dbee5f5c8329ad5944153d0f3613